### PR TITLE
Update watermark_encoding.py

### DIFF
--- a/src/watermark_encoding.py
+++ b/src/watermark_encoding.py
@@ -1,5 +1,5 @@
 import os, torch, time, argparse
-os.environ['CUDA_VISIBLE_DEVICES'] = '1'
+os.environ['CUDA_VISIBLE_DEVICES'] = '0'
 from vine_turbo import VINE_Turbo
 from accelerate.utils import set_seed
 from PIL import Image


### PR DESCRIPTION
Please note that the CUDA_VISIBLE_DEVICES value may typically default to 0 for most users. Setting it to 1 often results in the error: RuntimeError: No CUDA GPUs are available.
<img width="785" alt="image" src="https://github.com/user-attachments/assets/365673fa-68d4-41c6-a640-34150a95b58b">
