### PR TITLE
Fix typo in regeneration script name

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ python vine/w_bench_utils/regeneration/stochastic_regeneration.py  \
 
 - **Deterministic Regeneration (aka, Image Inversion):**
 ```shell
-python vine/w_bench_utils/regeneration/stochastic_regeneration.py \
+python vine/w_bench_utils/regeneration/deterministic_inversion.py \
   --wm_images_folder ./vine_encoded_wbench/512/DET_INVERSION_1K   \
   --edited_output_folder ./output/edited_wmed_wbench/DET_INVERSION_1K
 ```


### PR DESCRIPTION
Hi Shilin,
I was just reading through the README and noticed the command for Deterministic Regeneration was still calling the stochastic script, so I made a quick fix to point it to the correct inversion script.
Also, just a gentle follow-up on my previous request (Issue #17) for the lightweight evaluation results! I know you're likely busy, but having those baseline numbers would really help me out with an upcoming submission deadline. Thanks again!